### PR TITLE
Enable autocomplete for access token field

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -136,6 +136,7 @@
     type="text"
     bind:value={accessToken}
     placeholder="Enter access token"
+    autocomplete="on"
   />
   <button on:click={countToken}>Count Token</button>
   {#if isValidToken}


### PR DESCRIPTION
Fixes #4

Enable autocomplete for the access token input field.

* Add `autocomplete="on"` attribute to the access token input field in `src/routes/+page.svelte`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/isseikz/MermaidEditor/pull/5?shareId=8b634c14-9339-4fbd-8552-99c9b9282dbe).