### PR TITLE
Hide access token input content

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -147,9 +147,9 @@
 
 <header class="header">
   <input
-    type="text"
+    type="password"
     bind:value={accessToken}
-    placeholder="Enter access token"
+    placeholder="Enter access token (hidden)"
     autocomplete="on"
   />
   <button on:click={countToken}>Count Token</button>


### PR DESCRIPTION
Fixes #8

Change the input type of the access token input field to "password" to hide the input content.

* Update the placeholder text to "Enter access token (hidden)" to indicate that the input content is hidden.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/isseikz/MermaidEditor/pull/10?shareId=b39c73db-d059-4358-bcd5-17eff1c47cfd).