### PR TITLE
Convert HTML to Svelte 5 format and display on new page

### DIFF
--- a/src/routes/import-clipboard/+page.svelte
+++ b/src/routes/import-clipboard/+page.svelte
@@ -1,0 +1,48 @@
+<script>
+  let importedText = "";
+
+  const importFile = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        importedText = e.target.result;
+        console.log("Imported text:", importedText);
+      };
+      reader.readAsText(file);
+    }
+  };
+
+  const copyToClipboard = () => {
+    if (importedText) {
+      navigator.clipboard.writeText(importedText)
+        .then(() => {
+          alert("Text copied to clipboard!");
+        })
+        .catch(err => {
+          console.error("Failed to copy text:", err);
+        });
+    } else {
+      alert("No text imported yet.");
+    }
+  };
+</script>
+
+<style>
+  body {
+    font-family: sans-serif;
+  }
+  button {
+    padding: 10px 20px;
+    margin: 10px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    cursor: pointer;
+  }
+</style>
+
+<button on:click={() => document.getElementById('fileInput').click()}>Import .txt</button>
+<button on:click={copyToClipboard}>Copy to Clipboard</button>
+
+<input type="file" id="fileInput" accept=".txt" style="display: none;" on:change={importFile}>


### PR DESCRIPTION
Convert the provided HTML code to Svelte 5 format and display it on a new page.

* Create a new Svelte component `src/routes/import-clipboard/+page.svelte` to handle file import and clipboard functionality.
* Add HTML structure with buttons for importing and copying to clipboard.
* Add JavaScript logic to handle file import and clipboard copy.
* Add CSS styles for buttons and layout.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/isseikz/MermaidEditor/pull/12?shareId=9f0b609b-7c1f-4de9-a5d1-fdd1d1215d05).